### PR TITLE
Web routes and handlers for rendering go and jet pages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace github.com/cidekar/adele-framework => /Users/harrisondestefano/Documents
 require (
 	github.com/cidekar/adele-framework v0.0.0-00010101000000-000000000000
 	github.com/go-chi/chi/v5 v5.2.2
+	github.com/justinas/nosurf v1.2.0
 )
 
 require (
@@ -27,12 +28,11 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
-	github.com/justinas/nosurf v1.2.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/mailgun/mailgun-go/v4 v4.4.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
-	github.com/ory/dockertest/v3 v3.12.0 // indirect
+	github.com/petaki/inertia-go v1.5.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sendgrid/rest v2.6.3+incompatible // indirect
 	github.com/sendgrid/sendgrid-go v3.8.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/opencontainers/runc v1.2.3 h1:fxE7amCzfZflJO2lHXf4y/y8M1BoAqp+FVmG19o
 github.com/opencontainers/runc v1.2.3/go.mod h1:nSxcWUydXrsBZVYNSkTjoQ/N6rcyTtn+1SD5D4+kRIM=
 github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCyRCw=
 github.com/ory/dockertest/v3 v3.12.0/go.mod h1:aKNDTva3cp8dwOWwb9cWuX84aH5akkxXRvO7KCwWVjE=
+github.com/petaki/inertia-go v1.5.0 h1:ab5iyBVdAAMIHvAhTOG5UTCIkYnJQ/SuIFiKQm6eDYU=
+github.com/petaki/inertia-go v1.5.0/go.mod h1:0oATJU1bvDxYjCDE2Sms4j33hdMqePlpZ3cAIUvzPeA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,9 +1,26 @@
 package handlers
 
 import (
+	"net/http"
+
 	"github.com/cidekar/adele-framework"
 )
 
 type Handlers struct {
 	App *adele.Adele
+}
+
+func (h *Handlers) Home(w http.ResponseWriter, r *http.Request) {
+	err := h.App.Helpers.Render(w, r, "home", nil, nil)
+	if err != nil {
+		h.App.Log.Error("error rendering:", err)
+	}
+}
+
+func (h *Handlers) NotFound(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	err := h.App.Helpers.Render(w, r, "404", nil, nil)
+	if err != nil {
+		h.App.Log.Error("error rendering:", err)
+	}
 }

--- a/resources/views/404.jet
+++ b/resources/views/404.jet
@@ -1,0 +1,73 @@
+{{extends "./layouts/base.jet"}}
+
+{{block browserTitle()}}Adele{{end}}
+
+{{block css()}}
+
+{{end}}
+
+{{block pageContent()}}
+
+<style type="text/css">
+        :root {
+            --adele-pink: #EB4765;
+            --adele-white: #FBFBFB;
+            --adele-text: #490814;
+        }
+        body{
+            background-color: var(--adele-pink);
+            font-family: 'Roboto', sans-serif;
+        }
+        .container{
+            left: 50%;
+            position: fixed;
+            text-align: center;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 90%;
+        }
+        .console {
+            font-size:64px;
+            letter-spacing: -4px;
+            font-weight: 700;
+            font-style: italic;
+            text-align:center;
+            height:200px;
+            display:block;
+            position:relative;
+            color: var( --adele-white);
+            top:0;
+            bottom:0;
+            left:0;
+            right:0;
+            margin:auto;
+        }
+        .console::before{
+            content: "> "
+        }
+        .console-cursor {
+            display:inline-block;
+            position:relative;
+            font-style:normal;
+            top:-4px;
+            left:10px;
+        }
+        .console-text{
+            color:var(--adele-white);
+        }
+        .hide {
+            opacity:0;
+        }
+    </style>
+
+	<div class="container">
+
+        <div class="console"><span id="console-text">404</span><div class="console-cursor" id="console">&#95;</div></div>
+
+    </div>
+
+{{end}}
+
+{{block js()}}
+
+{{end}}

--- a/resources/views/home.jet
+++ b/resources/views/home.jet
@@ -1,0 +1,180 @@
+{{extends "./layouts/base.jet"}}
+
+{{block browserTitle()}}Adele{{end}}
+
+{{block css()}}
+
+{{end}}
+
+{{block pageContent()}}
+
+<style type="text/css">
+        :root {
+            --adele-pink: #EB4765;
+            --adele-white: #FBFBFB;
+            --adele-text: #490814;
+        }
+        body{
+            background-color: var(--adele-pink);
+            font-family: 'Roboto', sans-serif;
+        }
+        .container{
+            left: 50%;
+            position: fixed;
+            text-align: center;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 90%;
+        }
+        .console {
+            font-size:64px;
+            letter-spacing: -4px;
+            font-weight: 700;
+            font-style: italic;
+            text-align:center;
+            height:200px;
+            display:block;
+            position:relative;
+            color: var( --adele-white);
+            top:0;
+            bottom:0;
+            left:0;
+            right:0;
+            margin:auto;
+        }
+        .console::before{
+            content: "> "
+        }
+        .console-cursor {
+            display:inline-block;
+            position:relative;
+            font-style:normal;
+            top:-4px;
+            left:10px;
+        }
+        .console-text{
+            color:var(--adele-white);
+        }
+        .hide {
+            opacity:0;
+        }
+    </style>
+
+	<div class="container">
+
+        <div class="console"><span id="console-text"></span><div class="console-cursor" id="console">&#95;</div></div>
+
+        <script type="text/javascript">
+
+            run();
+
+            function run() {
+
+                const config = {
+                    counters: {
+                        letterCount: 1,
+                        langCount: 1,
+                    },
+                    cursorIsHidden: true,
+                    elements: {
+                        console: "console",
+                        cursor: "console-text"
+                    },
+                    direction: 'ltr',
+                    lang: ['Hey.', 'You can skip the wiring code.', 'Batteries are included.', 'ADELE'],
+                    speeds: {
+                        flash: 400,
+                        typeSlow: 120,
+                        typeFast: 70,
+                        delay: 1000
+                    },
+                    wait: false,
+                    id: null,
+                    typeSpeed: null,
+                    loop: false
+                }
+
+                const consoleText = document.getElementById(config.elements.cursor)
+
+                function cursorBlink(){
+                    const console = document.getElementById(config.elements.console);
+                        if (config.cursorIsHidden) {
+                            console.className = 'console-cursor hide'
+                            config.cursorIsHidden = false
+                            return
+                        }
+
+                        console.className = 'console-cursor'
+                        config.cursorIsHidden = true
+                }
+
+                function typing(){
+                    if (!config.wait) {
+                        consoleText.innerHTML = config.lang[0].substring(0, config.counters.letterCount)
+                        if(config.direction === 'ltr') {
+                            config.counters.letterCount++;
+                        } else if(config.direction === 'rtl') {
+                            config.counters.letterCount -= 1;
+                        }
+                    }
+                }
+
+                function atStart(){
+                    if (config.counters.letterCount == 0 && !config.wait) {
+                        config.wait = true;
+                        consoleText.innerHTML = config.lang[0].substring(0, config.counters.letterCount)
+                        window.setTimeout(function() {
+                            config.lang.push(config.lang.shift());
+                            config.direction = 'ltr'
+                            config.counters.letterCount++;
+                            config.wait = false;
+                            clearInterval(config.id)
+                            type()
+                        }, config.speeds.delay)
+                    }
+                }
+
+                function atEnd(){
+                    if (config.counters.letterCount === config.lang[0].length + 1 && !config.wait) {
+                        config.wait = true;
+                        window.setTimeout(function() {
+                            config.counters.langCount++
+                            config.direction = 'rtl';
+                            config.counters.letterCount -= 1;
+                            config.wait = false;
+                            clearInterval(config.id)
+                            type()
+                        }, 1000)
+                    }
+                }
+
+                function type() {
+                    if(!config.loop && config.counters.langCount > config.lang.length){
+                        return
+                    }
+                    if(config.direction === 'ltr') {
+                        config.typeSpeed = config.speeds.typeSlow
+                    } else {
+                        config.typeSpeed = config.speeds.typeFast
+                    }
+                     config.id = window.setInterval(() => {
+                        atStart()
+                        atEnd()
+                        typing()
+                    }, config.typeSpeed)
+                }
+
+                window.setInterval(() => {
+                    cursorBlink()
+                }, config.speeds.flash)
+
+                window.setTimeout(() => { type() }, 1000)
+            }
+        </script>
+    </div>
+
+{{end}}
+
+{{block js()}}
+
+{{end}}

--- a/resources/views/layouts/base.jet
+++ b/resources/views/layouts/base.jet
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+    <title>{{yield browserTitle()}}</title>
+
+    <meta name="csrf-token" content="{{.CSRFToken}}">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
+
+
+    {{yield css()}}
+
+</head>
+<body>
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 offset-md-2">
+
+            {{yield pageContent()}}
+
+        </div>
+    </div>
+</div>
+
+{{yield js()}}
+
+</body>
+</html>

--- a/routes-web.go
+++ b/routes-web.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/cidekar/adele-framework/mux"
@@ -17,14 +16,17 @@ func (a *application) WebRoutes() http.Handler {
 
 	r.Use(a.Middleware.NoSurf)
 
+	// 404 Route: Here is a catch-all web route for routing paths in the application
+	// that could not be found.
+
+	r.NotFound(a.Handlers.NotFound)
+
 	r.Route("/", func(mux chi.Router) {
 
 		// Web Routes: here is where you can add your web routes for the application. These
 		// routes are loaded by the router.
 
-		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "Welcome to Adele! \n")
-		})
+		r.Get("/", a.Handlers.Home)
 
 	})
 	return r


### PR DESCRIPTION
# :meat_on_bone: Mail
This PR adds templates and handlers for the Home and 404 views, rendered with Jet. The Home view gives us a clean, welcoming entry point, while the 404 view provides a clear response for when something goes off track.
It’s a small but important step toward making the app feel more polished and user-friendly.
